### PR TITLE
Add GitHub Actions workflow for Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Build Docker image
         run: docker build .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,18 @@
+name: Docker Build
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build .


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that runs on pushes and pull requests
- Build the repository Docker image on `ubuntu-latest` with read-only contents permissions

## Testing
- Not run (not requested)