### PR TITLE
Replace MAINTAINER with OCI authors label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.24.1
-MAINTAINER Yasuyuki YAMADA <yasuyuki.ymd@gmail.com>
+LABEL org.opencontainers.image.authors="Yasuyuki YAMADA <yasuyuki.ymd@gmail.com>"
 
 RUN apk add --no-cache openssh-server openssh-client rsync ansible py3-pip ca-certificates


### PR DESCRIPTION
## Summary
- Replace the deprecated `MAINTAINER` instruction with the OCI-compliant `org.opencontainers.image.authors` label
- Keep the author metadata unchanged while aligning the Dockerfile with current best practice

## Testing
- Not run (not requested)